### PR TITLE
Check for _NSZombie in AllocationTracker 

### DIFF
--- a/FBAllocationTracker.podspec
+++ b/FBAllocationTracker.podspec
@@ -15,6 +15,8 @@ Pod::Spec.new do |s|
   mrr_files = [
     'FBAllocationTracker/NSObject+FBAllocationTracker.h',
     'FBAllocationTracker/NSObject+FBAllocationTracker.mm',
+    'FBAllocationTracker/Generations/FBAllocationTrackerNSZombieSupport.h',
+    'FBAllocationTracker/Generations/FBAllocationTrackerNSZombieSupport.mm'
   ]
 
   files = Pathname.glob("FBAllocationTracker/**/*.{h,m,mm}")

--- a/FBAllocationTracker.xcodeproj/project.pbxproj
+++ b/FBAllocationTracker.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0943EBDB1CCE95C900238D89 /* FBAllocationTrackerNSZombieSupport.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0943EBD91CCE95C900238D89 /* FBAllocationTrackerNSZombieSupport.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		0943EBDC1CCE95C900238D89 /* FBAllocationTrackerNSZombieSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 0943EBDA1CCE95C900238D89 /* FBAllocationTrackerNSZombieSupport.h */; };
 		75BF0EC91C5BCEA000E0DAB6 /* FBAllocationTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 75BF0EC81C5BCEA000E0DAB6 /* FBAllocationTracker.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		75BF0EDE1C5BCF3200E0DAB6 /* FBAllocationTrackerFunctors.h in Headers */ = {isa = PBXBuildFile; fileRef = 75BF0ED01C5BCF3200E0DAB6 /* FBAllocationTrackerFunctors.h */; };
 		75BF0EDF1C5BCF3200E0DAB6 /* FBAllocationTrackerImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 75BF0ED11C5BCF3200E0DAB6 /* FBAllocationTrackerImpl.h */; };
@@ -36,6 +38,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0943EBD91CCE95C900238D89 /* FBAllocationTrackerNSZombieSupport.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FBAllocationTrackerNSZombieSupport.mm; sourceTree = "<group>"; };
+		0943EBDA1CCE95C900238D89 /* FBAllocationTrackerNSZombieSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBAllocationTrackerNSZombieSupport.h; sourceTree = "<group>"; };
 		75BF0EC51C5BCEA000E0DAB6 /* FBAllocationTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBAllocationTracker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		75BF0EC81C5BCEA000E0DAB6 /* FBAllocationTracker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBAllocationTracker.h; sourceTree = "<group>"; };
 		75BF0ECA1C5BCEA000E0DAB6 /* FBAllocationTracker-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "FBAllocationTracker-Info.plist"; sourceTree = "<group>"; };
@@ -120,6 +124,8 @@
 				75BF0ED91C5BCF3200E0DAB6 /* FBAllocationTrackerGeneration.mm */,
 				75BF0EDA1C5BCF3200E0DAB6 /* FBAllocationTrackerGenerationManager.h */,
 				75BF0EDB1C5BCF3200E0DAB6 /* FBAllocationTrackerGenerationManager.mm */,
+				0943EBDA1CCE95C900238D89 /* FBAllocationTrackerNSZombieSupport.h */,
+				0943EBD91CCE95C900238D89 /* FBAllocationTrackerNSZombieSupport.mm */,
 			);
 			path = Generations;
 			sourceTree = "<group>";
@@ -141,6 +147,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				75BF0EC91C5BCEA000E0DAB6 /* FBAllocationTracker.h in Headers */,
+				0943EBDC1CCE95C900238D89 /* FBAllocationTrackerNSZombieSupport.h in Headers */,
 				75BF0EE11C5BCF3200E0DAB6 /* FBAllocationTrackerManager.h in Headers */,
 				75BF0EE31C5BCF3200E0DAB6 /* FBAllocationTrackerSummary.h in Headers */,
 				75BF0EE91C5BCF3200E0DAB6 /* NSObject+FBAllocationTracker.h in Headers */,
@@ -252,6 +259,7 @@
 				75BF0EEA1C5BCF3200E0DAB6 /* NSObject+FBAllocationTracker.mm in Sources */,
 				75BF0EE81C5BCF3200E0DAB6 /* FBAllocationTrackerGenerationManager.mm in Sources */,
 				75BF0EE01C5BCF3200E0DAB6 /* FBAllocationTrackerImpl.mm in Sources */,
+				0943EBDB1CCE95C900238D89 /* FBAllocationTrackerNSZombieSupport.mm in Sources */,
 				75BF0EE41C5BCF3200E0DAB6 /* FBAllocationTrackerSummary.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FBAllocationTracker/Generations/FBAllocationTrackerGeneration.mm
+++ b/FBAllocationTracker/Generations/FBAllocationTrackerGeneration.mm
@@ -9,6 +9,8 @@
 
 #import "FBAllocationTrackerGeneration.h"
 
+#include "FBAllocationTrackerNSZombieSupport.h"
+
 namespace FB { namespace AllocationTracker {
   void Generation::add(__unsafe_unretained id object) {
     Class aCls = [object class];
@@ -46,11 +48,16 @@ namespace FB { namespace AllocationTracker {
          Retain object and add it to returnValue.
          This operation can be unsafe since we are retaining object that could
          be deallocated on other thread.
+
+         When NSZombie enabled, we can find if object has been deallocated by checking its class name.
          */
-        returnValue.push_back(object);
+        if (!fb_isZombieObject(object)) {
+          returnValue.push_back(object);
+        }
       }
     }
 
     return returnValue;
   }
+
 } }

--- a/FBAllocationTracker/Generations/FBAllocationTrackerNSZombieSupport.h
+++ b/FBAllocationTracker/Generations/FBAllocationTrackerNSZombieSupport.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ Returns whether `object` is the zombie object.
+ 
+ @return `true` if `object` is nil.
+ @return `false` if `object` is not nil and NSZombieEnabled = NO.
+ */
+bool fb_isZombieObject(_Nullable id object);
+
+/**
+ Returns whether runtime has NSZombie detection enabled.
+ */
+bool fb_isNSZombieEnabled(void);

--- a/FBAllocationTracker/Generations/FBAllocationTrackerNSZombieSupport.mm
+++ b/FBAllocationTracker/Generations/FBAllocationTrackerNSZombieSupport.mm
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#if __has_feature(objc_arc)
+#error This file must be compiled with MRR. Use -fno-objc-arc flag.
+#endif
+
+#include "FBAllocationTrackerNSZombieSupport.h"
+
+bool fb_isZombieObject(_Nullable id object) {
+  if (object == nil) { return true; }
+  if (!fb_isNSZombieEnabled()) { return false; }
+
+  const char *className = object_getClassName(object);
+  static const char zombiePrefix[] = "_NSZombie";
+  return strncmp(className, zombiePrefix, sizeof(zombiePrefix) - 1) == 0;
+}
+
+bool fb_isNSZombieEnabled(void) {
+  static bool zombieEnabled = false;
+
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    char *NSZombieEnabledEnv = getenv("NSZombieEnabled");
+
+    if (NSZombieEnabledEnv != NULL) {
+      zombieEnabled = strcmp(NSZombieEnabledEnv, "YES") == 0;
+    }
+    else {
+      zombieEnabled = false;
+    }
+  });
+
+  return zombieEnabled;
+}

--- a/FBAllocationTracker/NSObject+FBAllocationTracker.mm
+++ b/FBAllocationTracker/NSObject+FBAllocationTracker.mm
@@ -8,7 +8,7 @@
  */
 
 #if __has_feature(objc_arc)
-#error This file must be compiled with MRR. Use -fobjc-no-arc flag.
+#error This file must be compiled with MRR. Use -fno-objc-arc flag.
 #endif
 
 #import "NSObject+FBAllocationTracker.h"

--- a/FBAllocationTrackerTests/FBAllocationTrackerGenerationsTests.mm
+++ b/FBAllocationTrackerTests/FBAllocationTrackerGenerationsTests.mm
@@ -11,6 +11,7 @@
 
 #import "FBAllocationTrackerGeneration.h"
 #import "FBAllocationTrackerGenerationManager.h"
+#include "FBAllocationTrackerNSZombieSupport.h"
 
 @interface _FBATTestClass : NSObject
 @end
@@ -161,6 +162,18 @@
   for (id object in objects) {
     XCTAssertTrue([instances containsObject:object]);
   }
+}
+
+- (void)testThatNSZobmieClassDetectionWorks {
+  if (!fb_isNSZombieEnabled()) { return; }
+  
+  __unsafe_unretained id deallocatedObject = nil;
+  @autoreleasepool {
+    id testObject = [NSObject new];
+    deallocatedObject = testObject;
+  }
+  
+  XCTAssertTrue(fb_isZombieObject(deallocatedObject));
 }
 
 @end


### PR DESCRIPTION
to remove crashes when object deallocates on other thread.

I tried FBAllocationTracker with FBRetainCycleDetector on my production app and I get constant crashes, because the tracker tries to retain deallocated object. 

Right now, the only way for me to get any value from FBRetainCycleDetector is enable NSZombie and use my patch. 

Please provide your feedback. 
