### PR TITLE
[Podspec] Set platform to 7.0

### DIFF
--- a/FBAllocationTracker.podspec
+++ b/FBAllocationTracker.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/facebook/FBAllocationTracker"
   s.license      = "BSD"
   s.author       = { "Grzegorz Pstrucha" => "gricha@fb.com" }
-  s.platform     = :ios, "8.0"
+  s.platform     = :ios, "7.0"
   s.source       = {
     :git => "https://github.com/facebook/FBAllocationTracker.git",
     :tag => "0.1.2"


### PR DESCRIPTION
This pull request allows projects with a deployment target of iOS 7.0 to integrate FBAllocationTracker.
