### PR TITLE
Do not handle Nil classes

### DIFF
--- a/FBAllocationTracker/FBAllocationTrackerImpl.mm
+++ b/FBAllocationTracker/FBAllocationTrackerImpl.mm
@@ -148,8 +148,11 @@ namespace FB { namespace AllocationTracker {
   }
 
   static bool _isClassBlacklisted(Class aCls) {
-    // We want to omit some classes for performance reasons
+    if (aCls == Nil) {
+      return true;
+    }
 
+    // We want to omit some classes for performance reasons
     static Class blacklistedTaggedPointerContainerClass;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{

--- a/FBAllocationTracker/FBAllocationTrackerImpl.mm
+++ b/FBAllocationTracker/FBAllocationTrackerImpl.mm
@@ -147,9 +147,9 @@ namespace FB { namespace AllocationTracker {
     return isTracking;
   }
 
-  static bool _isClassBlacklisted(Class aCls) {
+  static bool _shouldTrackClass(Class aCls) {
     if (aCls == Nil) {
-      return true;
+      return false;
     }
 
     // We want to omit some classes for performance reasons
@@ -160,16 +160,16 @@ namespace FB { namespace AllocationTracker {
     });
 
     if (aCls == blacklistedTaggedPointerContainerClass) {
-      return true;
+      return false;
     }
 
-    return false;
+    return true;
   }
 
   void incrementAllocations(__unsafe_unretained id obj) {
     Class aCls = [obj class];
 
-    if (_isClassBlacklisted(aCls)) {
+    if (!_shouldTrackClass(aCls)) {
       return;
     }
 
@@ -187,7 +187,7 @@ namespace FB { namespace AllocationTracker {
   void incrementDeallocations(__unsafe_unretained id obj) {
     Class aCls = [obj class];
 
-    if (_isClassBlacklisted(aCls)) {
+    if (!_shouldTrackClass(aCls)) {
       return;
     }
 


### PR DESCRIPTION
If for some reason an initialized object does not return a valid class, the object should not be handled.

For example RestKit implements a class (_RKMappingSourceObject_), that forwards it's _class_ method to a property. Because this property is _nil_ during allocation, we get _Nil_ as class for an allocated _RKMappingSourceObject_.

I would suggest to rename __isClassBlacklisted()_ because _Nil_ doesn't really count as a "blacklisted" Class IMO. Maybe __shouldTrackClass()_ or __shouldHandleClass()_?
