### PR TITLE
Retain object to prevent nil-ing out object

### DIFF
--- a/FBAllocationTracker/FBAllocationTrackerImpl.mm
+++ b/FBAllocationTracker/FBAllocationTrackerImpl.mm
@@ -250,14 +250,14 @@ namespace FB { namespace AllocationTracker {
 
   void enableGenerations() {
     std::lock_guard<std::mutex> l(*_lock);
-    
+
     if (_generationManager) {
       return;
     }
-    
+
     _generationManager = new GenerationManager();
   }
-  
+
   void disableGenerations(void) {
     std::lock_guard<std::mutex> l(*_lock);
 
@@ -274,7 +274,7 @@ namespace FB { namespace AllocationTracker {
 
   FullGenerationSummary generationSummary() {
     std::lock_guard<std::mutex> l(*_lock);
-    
+
     if (_generationManager) {
       return _generationManager->summary();
     }
@@ -325,8 +325,9 @@ namespace FB { namespace AllocationTracker {
       }
 
       for (const auto &obj: instancesFromGeneration) {
-        if (obj) {
-          [instances addObject:obj];
+        id retainedObject = obj;
+        if (retainedObject) {
+          [instances addObject:retainedObject];
         }
       }
     }


### PR DESCRIPTION
In mutithreaded contexts it's possible that objects may be released by another thread in between iterating in the for-loop and adding it to the array. This makes sure the object is retained before adding it to the array to prevent this.
