### PR TITLE
Implement description for FBAllocationTrackerSummary

### DIFF
--- a/FBAllocationTracker/FBAllocationTrackerSummary.m
+++ b/FBAllocationTracker/FBAllocationTrackerSummary.m
@@ -28,4 +28,9 @@
   return self;
 }
 
+-(NSString *)description
+{
+  return [NSString stringWithFormat:@"%@: allocations=%@ deallocations=%@ alive=%@ size=%@", _className, @(_allocations), @(_deallocations), @(_aliveObjects), @(_instanceSize)];
+}
+
 @end


### PR DESCRIPTION
Makes dumping the current state of the world much nicer from debugger.

For instance: `(lldb) po [[FBAllocationTrackerManager sharedManager] currentAllocationSummary]`
