### PR TITLE
Switches tracking from +alloc to +allocWithZone:

### DIFF
--- a/FBAllocationTracker.podspec
+++ b/FBAllocationTracker.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author       = { "Grzegorz Pstrucha" => "gricha@fb.com" }
   s.platform     = :ios, "7.0"
   s.source       = {
-    :git => "https://github.com/facebook/FBAllocationTracker.git",
+    :git => "https://github.com/grigorye/FBAllocationTracker.git",
     :tag => "0.1.5"
   }
   s.source_files  = "FBAllocationTracker", "FBAllocationTracker/**/*.{h,m,mm}"

--- a/FBAllocationTracker.podspec
+++ b/FBAllocationTracker.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author       = { "Grzegorz Pstrucha" => "gricha@fb.com" }
   s.platform     = :ios, "7.0"
   s.source       = {
-    :git => "https://github.com/grigorye/FBAllocationTracker.git",
+    :git => "https://github.com/facebook/FBAllocationTracker.git",
     :tag => "0.1.5"
   }
   s.source_files  = "FBAllocationTracker", "FBAllocationTracker/**/*.{h,m,mm}"

--- a/FBAllocationTracker.xcodeproj/project.pbxproj
+++ b/FBAllocationTracker.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		75BF0EFB1C5BCFAF00E0DAB6 /* FBAllocationTrackerGenerationsTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 75BF0EFA1C5BCFAF00E0DAB6 /* FBAllocationTrackerGenerationsTests.mm */; };
 		75D15A121CE2A88200C18F06 /* FBAllocationTrackerDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 75D15A111CE2A88200C18F06 /* FBAllocationTrackerDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7ACA3EA11CD811E8003C2688 /* FBAllocationTrackerHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ACA3E9F1CD811E8003C2688 /* FBAllocationTrackerHelpers.h */; };
+		A18DB4331FD7702500254FF8 /* FBAllocationTrackerManagerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = A18DB4321FD7702500254FF8 /* FBAllocationTrackerManagerTests.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +64,7 @@
 		75BF0EFA1C5BCFAF00E0DAB6 /* FBAllocationTrackerGenerationsTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FBAllocationTrackerGenerationsTests.mm; sourceTree = "<group>"; };
 		75D15A111CE2A88200C18F06 /* FBAllocationTrackerDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBAllocationTrackerDefines.h; sourceTree = "<group>"; };
 		7ACA3E9F1CD811E8003C2688 /* FBAllocationTrackerHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBAllocationTrackerHelpers.h; sourceTree = "<group>"; };
+		A18DB4321FD7702500254FF8 /* FBAllocationTrackerManagerTests.mm */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.cpp.objcpp; path = FBAllocationTrackerManagerTests.mm; sourceTree = "<group>"; tabWidth = 2; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,6 +143,7 @@
 			children = (
 				75BF0EF31C5BCF8100E0DAB6 /* FBAllocationTrackerTests-Info.plist */,
 				75BF0EFA1C5BCFAF00E0DAB6 /* FBAllocationTrackerGenerationsTests.mm */,
+				A18DB4321FD7702500254FF8 /* FBAllocationTrackerManagerTests.mm */,
 			);
 			path = FBAllocationTrackerTests;
 			sourceTree = "<group>";
@@ -276,6 +279,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A18DB4331FD7702500254FF8 /* FBAllocationTrackerManagerTests.mm in Sources */,
 				75BF0EFB1C5BCFAF00E0DAB6 /* FBAllocationTrackerGenerationsTests.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FBAllocationTracker/FBAllocationTrackerImpl.mm
+++ b/FBAllocationTracker/FBAllocationTrackerImpl.mm
@@ -75,8 +75,8 @@ namespace {
     _didCopyOriginalMethods = true;
 
     replaceSelectorWithSelector([NSObject class],
-                                @selector(fb_originalAlloc),
-                                @selector(alloc),
+                                @selector(fb_originalAllocWithZone:),
+                                @selector(allocWithZone:),
                                 FBClassMethod);
 
     replaceSelectorWithSelector([NSObject class],
@@ -89,8 +89,8 @@ namespace {
     prepareOriginalMethods();
 
     replaceSelectorWithSelector([NSObject class],
-                                @selector(alloc),
-                                @selector(fb_newAlloc),
+                                @selector(allocWithZone:),
+                                @selector(fb_newAllocWithZone:),
                                 FBClassMethod);
 
     replaceSelectorWithSelector([NSObject class],
@@ -104,7 +104,7 @@ namespace {
 
     replaceSelectorWithSelector([NSObject class],
                                 @selector(alloc),
-                                @selector(fb_originalAlloc),
+                                @selector(fb_originalAllocWithZone:),
                                 FBClassMethod);
 
     replaceSelectorWithSelector([NSObject class],

--- a/FBAllocationTracker/FBAllocationTrackerImpl.mm
+++ b/FBAllocationTracker/FBAllocationTrackerImpl.mm
@@ -103,7 +103,7 @@ namespace {
     prepareOriginalMethods();
 
     replaceSelectorWithSelector([NSObject class],
-                                @selector(alloc),
+								@selector(allocWithZone:),
                                 @selector(fb_originalAllocWithZone:),
                                 FBClassMethod);
 

--- a/FBAllocationTracker/NSObject+FBAllocationTracker.h
+++ b/FBAllocationTracker/NSObject+FBAllocationTracker.h
@@ -22,10 +22,10 @@
 
 @interface NSObject (FBAllocationTracker)
 
-+ (nonnull id)fb_originalAlloc;
++ (nonnull id)fb_originalAllocWithZone:(nullable id)zone;
 - (void)fb_originalDealloc;
 
-+ (nonnull id)fb_newAlloc;
++ (nonnull id)fb_newAllocWithZone:(nullable id)zone;
 - (void)fb_newDealloc;
 
 @end

--- a/FBAllocationTracker/NSObject+FBAllocationTracker.mm
+++ b/FBAllocationTracker/NSObject+FBAllocationTracker.mm
@@ -20,9 +20,9 @@
 
 @implementation NSObject (FBAllocationTracker)
 
-+ (id)fb_originalAlloc
++ (id)fb_originalAllocWithZone:(id)zone
 {
-  // Placeholder for original alloc
+  // Placeholder for original allocWithZone:
   return nil;
 }
 
@@ -31,9 +31,9 @@
   // Placeholder for original dealloc
 }
 
-+ (id)fb_newAlloc
++ (id)fb_newAllocWithZone:(id)zone
 {
-  id object = [self fb_originalAlloc];
+  id object = [self fb_originalAllocWithZone:zone];
   FB::AllocationTracker::incrementAllocations(object);
   return object;
 }

--- a/FBAllocationTrackerTests/FBAllocationTrackerManagerTests.mm
+++ b/FBAllocationTrackerTests/FBAllocationTrackerManagerTests.mm
@@ -32,9 +32,7 @@
 - (void)tearDown
 {
   [[FBAllocationTrackerManager sharedManager] disableGenerations];
-#if 0 // Crashes otherwise under iPhone 8 Plus Simulator/iOS 11.2
   [[FBAllocationTrackerManager sharedManager] stopTrackingAllocations];
-#endif
   
   [super tearDown];
 }

--- a/FBAllocationTrackerTests/FBAllocationTrackerManagerTests.mm
+++ b/FBAllocationTrackerTests/FBAllocationTrackerManagerTests.mm
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FBAllocationTrackerManager.h"
+
+@interface _FBATMTestClass : NSObject
+@end
+@implementation _FBATMTestClass
+@end
+
+@interface FBAllocationTrackerManagerTests : XCTestCase
+@end
+
+@implementation FBAllocationTrackerManagerTests
+
+- (void)setUp
+{
+  [super setUp];
+  
+  [[FBAllocationTrackerManager sharedManager] startTrackingAllocations];
+  [[FBAllocationTrackerManager sharedManager] enableGenerations];
+}
+
+- (void)tearDown
+{
+  [[FBAllocationTrackerManager sharedManager] disableGenerations];
+#if 0 // Crashes otherwise under iPhone 8 Plus Simulator/iOS 11.2
+  [[FBAllocationTrackerManager sharedManager] stopTrackingAllocations];
+#endif
+  
+  [super tearDown];
+}
+
+- (void)testAllocWithZoneIsTracked {
+    XCTAssertEqualObjects(@[], [[FBAllocationTrackerManager sharedManager] instancesOfClasses:@[[_FBATMTestClass class]]]);
+    id object = [[_FBATMTestClass allocWithZone:nil] init];
+    XCTAssertEqualObjects(@[object], [[FBAllocationTrackerManager sharedManager] instancesOfClasses:@[[_FBATMTestClass class]]]);
+}
+
+@end


### PR DESCRIPTION
Below is a fix for the problem that I faced today while trying to use `FBAllocationTracker` for simple in-app leak detection. It turns out that `+alloc` is not used at least for some objects loaded from .storyboards (nibs?), but `+allocWithZone:` is used instead. Particularly, in my case I saw it like _deallocations_ tracked for navigation controllers (when they're disposed), without tracking allocations, hence the (live) count of navigation controllers in `currentAllocationSummary` eventually decreased below zero.

You can easily check it yourself with storyboards, I've added unit test illustrating the problem as well.

Overall I believe it makes sense to patch `+allocWithZone:` instead of `+alloc` just because it's kind of historical thing (and was used freely in "old" source bases) - otherwise you had a great chance to miss it like in this case with storyboards.

Just in case, there's another, (completely unrelated) problem with `FBAllocationTrackerManager`: tests are crashing if I invoke `-stopTrackingAllocations` in `-tearDown` (even with empty test body). I had to disable it, just to allow all tests to run.