### PR TITLE
Fixed warnings about implicit retains.

### DIFF
--- a/FBAllocationTracker/FBAllocationTrackerManager.mm
+++ b/FBAllocationTracker/FBAllocationTrackerManager.mm
@@ -67,19 +67,19 @@ BOOL FBIsFBATEnabledInThisBuild(void)
 - (void)enableGenerations
 {
   dispatch_async(_queue, ^{
-    if (_generationsClients == 0) {
+    if (self->_generationsClients == 0) {
       FB::AllocationTracker::enableGenerations();
       FB::AllocationTracker::markGeneration();
     }
-    _generationsClients += 1;
+    self->_generationsClients += 1;
   });
 }
 
 - (void)disableGenerations
 {
   dispatch_async(_queue, ^{
-    _generationsClients -= 1;
-    if (_generationsClients <= 0) {
+    self->_generationsClients -= 1;
+    if (self->_generationsClients <= 0) {
       FB::AllocationTracker::disableGenerations();
     }
   });


### PR DESCRIPTION
This is required to pass `pod lib lint` among other things.